### PR TITLE
Oxidize merge sort implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+// skipping Karatsub multiplication because I'm struggling with the concept and want
+// to make forward progress
+
+pub mod merge_sort;

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,14 +57,19 @@ fn merge(v1: Vec<i32>, v2: Vec<i32>) -> Vec<i32> {
     ret
 }
 
-#[test]
-fn sort_8_ints () {
-    let v = vec![2,4,3,5,8,6,7,1];
-    assert_eq!(vec![1,2,3,4,5,6,7,8], merge_sort(v));
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn sort_7_ints(){
-    let v = vec![2,4,3,5,6,7,1];
-    assert_eq!(vec![1,2,3,4,5,6,7], merge_sort(v));
+    #[test]
+    fn sort_8_ints () {
+        let v = vec![2,4,3,5,8,6,7,1];
+        assert_eq!(vec![1,2,3,4,5,6,7,8], merge_sort(v));
+    }
+
+    #[test]
+    fn sort_7_ints(){
+        let v = vec![2,4,3,5,6,7,1];
+        assert_eq!(vec![1,2,3,4,5,6,7], merge_sort(v));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,16 +41,13 @@ fn merge(v1: Vec<i32>, v2: Vec<i32>) -> Vec<i32> {
     for _ in 0..v1.len() + v2.len() {
         if v1_index >= v1.len() {
             ret.push(v2[v2_index]);
-            v2_index = v2_index + 1;
-        } else if v2_index >= v2.len() {
+            v2_index += 1;
+        } else if v2_index >= v2.len() || v1[v1_index] < v2[v2_index] {
             ret.push(v1[v1_index]);
-            v1_index = v1_index + 1;
-        } else if v1[v1_index] < v2[v2_index] {
-            ret.push(v1[v1_index]);
-            v1_index = v1_index + 1;
+            v1_index += 1;
         } else {
             ret.push(v2[v2_index]);
-            v2_index = v2_index + 1;
+            v2_index += 1;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,4 +69,16 @@ mod tests {
         let v = vec![2, 4, 3, 5, 6, 7, 1];
         assert_eq!(vec![1, 2, 3, 4, 5, 6, 7], merge_sort(v));
     }
+
+    #[test]
+    fn already_sorted() {
+        let v = vec![1, 2, 3, 4, 5, 6, 7, 8];
+        assert_eq!(vec![1, 2, 3, 4, 5, 6, 7, 8], merge_sort(v));
+    }
+
+    #[test]
+    fn worst_case() {
+        let v = vec![8, 7, 6, 5, 4, 3, 2, 1];
+        assert_eq!(vec![1, 2, 3, 4, 5, 6, 7, 8], merge_sort(v));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,8 @@ fn main() {
 /// recursive application, but you combine the results back together in a way that keeps you from
 /// having to go back through every other value
 fn merge_sort(mut input: Vec<i32>) -> Vec<i32> {
-    if input.len() < 2{
-        return input
+    if input.len() < 2 {
+        return input;
     }
     let split = input.split_off(input.len().div(2));
 
@@ -59,14 +59,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn sort_8_ints () {
-        let v = vec![2,4,3,5,8,6,7,1];
-        assert_eq!(vec![1,2,3,4,5,6,7,8], merge_sort(v));
+    fn sort_8_ints() {
+        let v = vec![2, 4, 3, 5, 8, 6, 7, 1];
+        assert_eq!(vec![1, 2, 3, 4, 5, 6, 7, 8], merge_sort(v));
     }
 
     #[test]
-    fn sort_7_ints(){
-        let v = vec![2,4,3,5,6,7,1];
-        assert_eq!(vec![1,2,3,4,5,6,7], merge_sort(v));
+    fn sort_7_ints() {
+        let v = vec![2, 4, 3, 5, 6, 7, 1];
+        assert_eq!(vec![1, 2, 3, 4, 5, 6, 7], merge_sort(v));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,6 @@
 // TODO: figure out the right workspace setup so that I can have each problem as its own bin
 //  but in the same project
 
-use std::ops::Div;
-
 fn main() {
     println!("Hello, world!");
 }
@@ -22,7 +20,8 @@ fn merge_sort(mut input: Vec<i32>) -> Vec<i32> {
     if input.len() < 2 {
         return input;
     }
-    let split = input.split_off(input.len().div(2));
+
+    let split = input.split_off(input.len() / 2);
 
     // recurse with both sides
     let a = merge_sort(input);

--- a/src/merge_sort.rs
+++ b/src/merge_sort.rs
@@ -22,25 +22,25 @@ pub fn merge_sort(mut input: Vec<i32>) -> Vec<i32> {
 
 fn merge(v1: Vec<i32>, v2: Vec<i32>) -> Vec<i32> {
     let mut ret = Vec::new();
-    let mut v1_index = 0;
-    let mut v2_index = 0;
 
-    // to handle odd-length inputs, we need to iterate for the total number of output slots
-    // TODO: this is hideous - figure out the best way to clean up
-    for _ in 0..v1.len() + v2.len() {
-        if v1_index >= v1.len() {
-            ret.push(v2[v2_index]);
-            v2_index += 1;
-        } else if v2_index >= v2.len() || v1[v1_index] < v2[v2_index] {
-            ret.push(v1[v1_index]);
-            v1_index += 1;
-        } else {
-            ret.push(v2[v2_index]);
-            v2_index += 1;
+    let mut v1 = v1.into_iter().peekable();
+    let mut v2 = v2.into_iter().peekable();
+
+    loop {
+        // Inspect the next element of each list without modifying the iterator
+        match (v1.peek(), v2.peek()) {
+            // a < b, so push a while moving to the next element in v1
+            (Some(a), Some(b)) if a < b => ret.push(v1.next().unwrap()),
+            // b < a, so push b while moving to the next element in v2
+            (Some(a), Some(b)) if b <= a => ret.push(v2.next().unwrap()),
+            // v2 is empty, so push the last element(s) of v1
+            (Some(_), None) => ret.push(v1.next().unwrap()),
+            // v1 is empty, so push the last element(s) of v2
+            (None, Some(_)) => ret.push(v2.next().unwrap()),
+            // both lists are empty, so return
+            _ => return ret,
         }
     }
-
-    ret
 }
 
 #[cfg(test)]

--- a/src/merge_sort.rs
+++ b/src/merge_sort.rs
@@ -1,13 +1,3 @@
-// skipping Karatsub multiplication because I'm struggling with the concept and want
-// to make forward progress
-
-// TODO: figure out the right workspace setup so that I can have each problem as its own bin
-//  but in the same project
-
-fn main() {
-    println!("Hello, world!");
-}
-
 /// merge_sort
 /// * classic divide and conquer approach - break problem into sub-problems, solve recursively,
 /// and then combine the solutions
@@ -16,7 +6,7 @@ fn main() {
 /// of the algorithm. It seems like you still have to effectively process the entire vector through
 /// recursive application, but you combine the results back together in a way that keeps you from
 /// having to go back through every other value
-fn merge_sort(mut input: Vec<i32>) -> Vec<i32> {
+pub fn merge_sort(mut input: Vec<i32>) -> Vec<i32> {
     if input.len() < 2 {
         return input;
     }

--- a/src/merge_sort.rs
+++ b/src/merge_sort.rs
@@ -6,7 +6,7 @@
 /// of the algorithm. It seems like you still have to effectively process the entire vector through
 /// recursive application, but you combine the results back together in a way that keeps you from
 /// having to go back through every other value
-pub fn merge_sort(mut input: Vec<i32>) -> Vec<i32> {
+pub fn merge_sort<T: PartialOrd>(mut input: Vec<T>) -> Vec<T> {
     if input.len() < 2 {
         return input;
     }
@@ -20,7 +20,7 @@ pub fn merge_sort(mut input: Vec<i32>) -> Vec<i32> {
     merge(a, b)
 }
 
-fn merge(v1: Vec<i32>, v2: Vec<i32>) -> Vec<i32> {
+fn merge<T: PartialOrd>(v1: Vec<T>, v2: Vec<T>) -> Vec<T> {
     let mut ret = Vec::new();
 
     let mut v1 = v1.into_iter().peekable();
@@ -69,5 +69,11 @@ mod tests {
     fn worst_case() {
         let v = vec![8, 7, 6, 5, 4, 3, 2, 1];
         assert_eq!(vec![1, 2, 3, 4, 5, 6, 7, 8], merge_sort(v));
+    }
+
+    #[test]
+    fn sort_strings_lexicographically() {
+        let v = vec!["bromine", "darmstadtium", "aluminum", "cadmium"];
+        assert_eq!(vec!["aluminum", "bromine", "cadmium", "darmstadtium"], merge_sort(v));
     }
 }


### PR DESCRIPTION
I'll go through the commits one-by-one to explain the purpose of each of them.

## 7e01ce7

Rust common convention is to put unit tests in their own module marked with `#[cfg(test)]` (see the [`Test Organization Chapter`](https://doc.rust-lang.org/book/ch11-03-test-organization.html#test-organization) of the Rust Book for an explanation).

## df3d61c

[`cargo clippy`](https://github.com/rust-lang/rust-clippy) is my Rust linter of choice due to its thoroughness. Here, it was complaining that two of the if-branches in the `merge_sort` function had the same body, so I simply consolidated the conditional.

## 3a1bb7c

[`rustfmt`](https://github.com/rust-lang/rustfmt) is the easiest way to make your code conform to the Rust standards. I ran it before making any further changes.

## c9c5fc4

Before doing any logical changes, I wanted to be 100% certain that the core algorithm did not change (this helped a bunch on the following commits).

## 0987cdc

I noticed that you imported `std::ops::Div`, which can easily be replaced by the standard division operator, removing the unnecessary import.

## e2d194c

I saw a comment concerning refactoring the project into a set of sub-binaries. However, I noticed that you weren't using the `main` function and were instead writing unit tests. I liked this decision and ran with it, refactoring the code into a library instead of a binary.

## daa09f2

This is an unnecessary change (as the commit message suggests), but I wanted to show how you could leverage some of Rust's core features to make the implementation a lot more Rusty :). I accomplished this with two features: iterators and pattern matching. 

First, I noticed that your implementation already re-implemented iterators (keeping track of the head of a list and moving / consuming the head element), so they were a natural fit. There was one wrinkle with this move; we have to inspect the head of the iterator without consuming it (in order to compare the two head elements before deciding which gets pushed to the return list). This is accomplished via the [`Peekable`](https://doc.rust-lang.org/stable/std/iter/struct.Peekable.html) iterator variant. 

Next, I saw an if-elif-else chain, which are typically replaced by `match` statements in Rust. I think this code change is pretty straightforward. The only complication being the `if` guard at the end of the first two patterns. Basically, guards let us inline an if condition with a pattern, saving us another if-else block. 

I threw these changes inside of a `loop`, as the only state necessary is contained inside of the `v1` and `v2` iterators, and we simply break out of the loop when they are both empty. 

There are ways to make this code DRY-er, but I think it would lose a good deal of readability. 

## 042f8aa

The final improvement I could see was simply genericizing the function. The only constraint necessary on the individual elements was that you have to be able to compare them (via just `>` and `<=` in this case), meaning `T: PartialOrd`. 